### PR TITLE
fix: memory leak in VAD

### DIFF
--- a/src/AudioPipeline.zig
+++ b/src/AudioPipeline.zig
@@ -197,3 +197,21 @@ fn maybeRecordBuffer(self: *Self, to_sample: usize) !bool {
 test {
     _ = @import("./AudioPipeline/SegmentWriter.zig");
 }
+
+test "simple leak test" {
+    var pipeline = try init(
+        std.testing.allocator,
+        .{
+            .n_channels = 2,
+            .sample_rate = 48000,
+            .vad_config = .{
+                .alt_vad_machine_configs = &.{
+                    .{},
+                    .{},
+                }
+            }
+        },
+        null,
+    );
+    defer pipeline.deinit();
+}

--- a/src/AudioPipeline/VAD.zig
+++ b/src/AudioPipeline/VAD.zig
@@ -175,6 +175,7 @@ pub fn init(pipeline: *AudioPipeline, config: Config) !Self {
 
         for (0..alt_vad_configs.len) |i| {
             self.alt_vad_machines.?[i] = try VADMachine.init(allocator, alt_vad_configs[i], self);
+            n_alt_vad_initialized = i + 1;
         }
     }
 
@@ -184,6 +185,7 @@ pub fn init(pipeline: *AudioPipeline, config: Config) !Self {
 pub fn deinit(self: *Self) void {
     if (self.alt_vad_machines) |alt_vad| {
         for (alt_vad) |*v| v.deinit();
+        self.allocator.free(alt_vad);
     }
     self.vad_machine.deinit();
     self.denoiser.deinit();

--- a/src/AudioPipeline/VAD.zig
+++ b/src/AudioPipeline/VAD.zig
@@ -19,7 +19,7 @@ pub const Config = struct {
     use_denoiser: bool = true,
     vad_machine_config: VADMachine.Config = .{},
     // Alternative state machine configs for training
-    alt_vad_machine_configs: ?[]VADMachine.Config = null,
+    alt_vad_machine_configs: ?[]const VADMachine.Config = null,
 };
 
 pub const VADSpeechSegment = struct {


### PR DESCRIPTION
I found a memory leak in the VAD. It was actually complaining about the one in deinit when running.

The one in errdefer was never encountered, but it still has to be wrong IMO, because `n_alt_vad_initialized` is never changed from its initial value of 0. For simplification, this could be replaced with the same logic as used in deinit though?