### PR TITLE
fix: call deinit of simulation instance

### DIFF
--- a/src/simulator.zig
+++ b/src/simulator.zig
@@ -55,6 +55,8 @@ pub const Simulation = struct {
     pub fn deinit(self: *@This()) void {
         std.json.parseFree(SimulationJSON, self.allocator, self.original_json);
         if (self.resolved_out_path) |path| self.allocator.free(path);
+        for (self.instances) |*instance| instance.deinit();
+        self.allocator.free(self.instances);
     }
 };
 

--- a/src/simulator/SimulationInstance.zig
+++ b/src/simulator/SimulationInstance.zig
@@ -85,7 +85,7 @@ pub fn init(
     instance_json: SimulationInstanceJSON,
     sim_config: DynamicSimConfig,
 ) !Self {
-    const name = try allocator.dupeZ(u8, instance_json.name);
+    const name = try allocator.dupe(u8, instance_json.name);
     errdefer allocator.free(name);
 
     const audio_path = try fs.path.resolve(allocator, &.{ base_path, instance_json.audio_path });


### PR DESCRIPTION
Another small fix. `deinit` of the simulation instance was never called. 

Fixing this also required fixing another small bug. Previously, `allocator.dupeZ` was used. From the source docstring:

> Copies `m` to newly allocated memory, with a null-terminated element. Caller owns the memory.

This resulted in 

`error(gpa): Allocation size 12 bytes does not match free size 11.`

now, when `deinit` was actually called and `allocator.free` was called with `self.name`. The copy created with `allocator.dupe` does not have this additional null-termination.